### PR TITLE
Update main.ino - Add Mutex to protect mqtt publish and make multi-thread safe

### DIFF
--- a/main/main.ino
+++ b/main/main.ino
@@ -95,6 +95,8 @@ std::queue<JsonBundle> jsonQueue;
 #  include <driver/adc.h>
 // Mutex  to protect the queue
 SemaphoreHandle_t xQueueMutex;
+// Mutex to protect mqtt publish
+SemaphoreHandle_t xMqttMutex;
 bool blufiConnectAP = false;
 #endif
 
@@ -715,6 +717,12 @@ void pubMQTT(const char* topic, const char* payload) {
  */
 void pubMQTT(const char* topic, const char* payload, bool retainFlag) {
   if (SYSConfig.XtoMQTT && !SYSConfig.offline) {
+#ifdef ESP32
+    if (xSemaphoreTake(xMqttMutex, pdMS_TO_TICKS(QueueSemaphoreTimeOutTask)) == pdFALSE) {
+        Log.error(F("xMqttMutex not taken" CR));
+		return;
+    }
+#endif
     if (mqtt && mqtt->connected()) {
       SendReceiveIndicatorON();
       Log.trace(F("[ OMG->MQTT ] topic: %s msg: %s " CR), topic, payload);
@@ -722,6 +730,9 @@ void pubMQTT(const char* topic, const char* payload, bool retainFlag) {
     } else {
       Log.warning(F("MQTT not connected, aborting the publication" CR));
     }
+#ifdef ESP32
+	xSemaphoreGive(xMqttMutex);
+#endif
   } else {
     Log.notice(F("[ OMG->MQTT deactivated or offline] topic: %s msg: %s " CR), topic, payload);
   }
@@ -1280,6 +1291,7 @@ void setup() {
 #  endif
 #elif ESP32
   xQueueMutex = xSemaphoreCreateMutex();
+  xMqttMutex = xSemaphoreCreateMutex();
 #  if defined(ZboardM5STICKC) || defined(ZboardM5STICKCP) || defined(ZboardM5STACK) || defined(ZboardM5TOUGH)
   setupM5();
 #  endif


### PR DESCRIPTION
## Description: 
Fixes problem where MQTT discovery config strings were often corrupted due to collisions between coincident calls to pubMQTT since the PicoMQTT library is not thread safe.

Added new Mutex xMqttMutex to prevent collisions.

This corrects the final of the 2 corruption bugs called out in https://github.com/1technophile/OpenMQTTGateway/issues/2012


## Checklist:
  - [x ] The pull request is done against the latest development branch
  - [x ] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x ] I accept the [DCO](https://github.com/1technophile/OpenMQTTGateway/blob/development/docs/participate/development.md#developer-certificate-of-origin).
