### PR TITLE
Update main.ino - Remove restartESP from discover_prefix stanza

### DIFF
--- a/main/main.ino
+++ b/main/main.ino
@@ -3361,7 +3361,6 @@ void MQTTtoSYS(char* topicOri, JsonObject& SYSdata) { // json object decoding
 #ifdef ZmqttDiscovery
       if (SYSdata.containsKey("discovery_prefix")) {
         strncpy(discovery_prefix, SYSdata["discovery_prefix"], parameters_size);
-        restartESP = true; //Need to reset so all devices get re-discovered & published to new discovery_prefix
       }
 #endif
       if (SYSdata.containsKey("gateway_name")) {


### PR DESCRIPTION
Explicitly calling for `restartESP` results in other MQTT config variables never being saved since restart happens before MQTT reconnects and saves those variables.

Also, unnecessary, since all these variables trigger re-running `setupMQTT` which in turn triggers a `saveConfigs` and `ESPrestart` so long as any MQTT variable is changed.

## Description:


## Checklist:
  - [x ] The pull request is done against the latest development branch
  - [x ] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] I accept the [DCO](https://github.com/1technophile/OpenMQTTGateway/blob/development/docs/participate/development.md#developer-certificate-of-origin).
